### PR TITLE
Add ImageId Property to Cloud9 EC2 Environment Configuration

### DIFF
--- a/workshop-1/core.yml
+++ b/workshop-1/core.yml
@@ -516,6 +516,7 @@ Resources:
     Properties:
       AutomaticStopTimeMinutes: 30
       InstanceType: t2.small
+      ImageId: amazonlinux-2023-x86_64
       Name: !Sub Project-${AWS::StackName}
       SubnetId: !Ref PublicSubnetOne
 


### PR DESCRIPTION
### Overview
This PR introduces the `ImageId` property to the Cloud9 EC2 environment configuration in our CloudFormation template. 

### Context
I ran into errors deploying this and checked documentation, https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-cloud9-environmentec2.html#cfn-cloud9-environmentec2-imageid which shows ImageId is a required field as of December 04, 2023.

### Changes
- Updated `AWS::Cloud9::EnvironmentEC2` resource block in the CloudFormation YAML template to include the `ImageId` property.
- Specified an AMI ID that aligns with our latest approved baseline (amazonlinux-2023-x86_64

### Testing
- Validated the CloudFormation template update by deploying a test stack. Verified that the Cloud9 environment initializes correctly with the specified AMI.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
